### PR TITLE
Fix scrolling in text panels (#preview)

### DIFF
--- a/style.css
+++ b/style.css
@@ -68,6 +68,9 @@ li {
     -ms-user-select: none;
     user-select: none;
     cursor: default;
+    
+    max-height: 90%;
+    overflow: scroll;
 }
 
 #textPreview {


### PR DESCRIPTION
Closes #41. Not a super great long term solution though, but it seems to work with just this 2 line CSS change. I think a better solution would ultimately be clean up the markup/structure of the HTML file such that flexbox can be used to make the editing/preview area take up whatever rest of the Y screen space that is not taken up by the top loading bar. If it's ok though I would like to put a little bit of time into refining the UI/structure of the page and submit a PR today or tomorrow (probably tomorrow) to make that flexbox/structure change happen, but this temporary fix should to the trick for now.